### PR TITLE
Fix bug with loading default schema

### DIFF
--- a/OpenAPIFile.js
+++ b/OpenAPIFile.js
@@ -196,7 +196,7 @@ OpenAPIFile.prototype.getLocalizedPath = function(locale) {
  * @returns {String} the localized text of this file
  */
 OpenAPIFile.prototype.localizeText = function(translations, locale) {
-    var jsonTranslationSet = this.API.newTranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
+    var jsonTranslationSet = this.API.newTranslationSet(this.project ? this.project.sourceLocale : 'zxx-XX');
 
     this.jsonSet.getAll().forEach(function(res) {
         if (res.resType === 'string') {

--- a/OpenAPIFileType.js
+++ b/OpenAPIFileType.js
@@ -18,6 +18,7 @@
  */
 
 var fs = require('fs');
+const path = require('path');
 var log4js = require('log4js');
 
 var JsonFileType = require('ilib-loctool-json/JsonFileType');
@@ -36,19 +37,19 @@ var OpenAPIFileType = function(project) {
     this.newres = this.API.newTranslationSet(project.getSourceLocale());
     this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
 
-    this.defaultSchema = fs.readFileSync('./schema.json', 'utf-8');
-
-    if (!project.settings.openapi.schemas) {
-        project.settings.openapi.schemas = [];
-    }
-    // Default OpenAPI schema bundled with the plugin.
-    project.settings.openapi.schemas.unshift('./schema.json');
-
     // Copy over openapi config to json key to enable support of mappings from the json plugin.
     project.settings.json = project.settings.openapi;
 
-    this.jsonFileType = new JsonFileType(project);
     this.markdownFileType = new MarkdownFileType(project);
+    this.jsonFileType = new JsonFileType(project);
+
+    // Load default OpenAPI schema bundled with the plugin.
+    var defaultSchemaPath = path.resolve(__dirname, 'schema.json');
+    this.jsonFileType.loadSchemaFile(defaultSchemaPath);
+    this.jsonFileType.findRefs(
+        this.jsonFileType.schemas[defaultSchemaPath],
+        this.jsonFileType.schemas[defaultSchemaPath],
+        '#');
 }
 
 /**
@@ -196,9 +197,5 @@ OpenAPIFileType.prototype.addSet = function(set) {
 OpenAPIFileType.prototype.name = function() {
     return 'OpenAPI File Type';
 };
-
-OpenAPIFileType.prototype.getDefaultSchema = function() {
-    return this.defaultSchema;
-}
 
 module.exports = OpenAPIFileType;

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.0.1
+
+- Fix errors while loading default schema, relative path was replaced
+with an absolute.
+
 ### v1.0.0
 
 - initial version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-openapi",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./OpenAPIFileType.js",
     "description": "A loctool plugin that knows how to localize openapi files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Replace relative path with an absolute to avoid errors while using plugin with loctool.