### PR TITLE
Fix problem with empty objects used as array elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "test:watch": "jest --watch",
         "debug": "node --inspect-brk node_modules/.bin/jest -i",
         "clean": "git clean -f -d test",
-        "postinstall": "conditional-install"
+        "prepare": "conditional-install"
     },
     "engines": {
         "node": ">=8.0"
@@ -54,7 +54,7 @@
     "dependencies": {
         "ilib": "^14.19.0",
         "ilib-loctool-ghfm": "^1.11.4",
-        "ilib-loctool-json": "^1.5.3"
+        "ilib-loctool-json": "^1.5.4"
     },
     "devDependencies": {
         "conditional-install": "^1.0.1",
@@ -62,14 +62,10 @@
     },
     "conditionalDependencies": {
         "process.versions.node < 14.0.0": {
-            "jest": "^26.0.0",
-            "jest-mock": "^26.0.0",
-            "expect": "^26.0.0"
+            "jest": "^26.0.0"
         },
         "process.versions.node >= 14.0.0": {
-            "jest": "^29.0.0",
-            "jest-mock": "^29.0.0",
-            "expect": "^29.0.0"
+            "jest": "^29.0.0"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -45,18 +45,31 @@
         "test": "jest",
         "test:watch": "jest --watch",
         "debug": "node --inspect-brk node_modules/.bin/jest -i",
-        "clean": "git clean -f -d test"
+        "clean": "git clean -f -d test",
+        "postinstall": "conditional-install"
     },
     "engines": {
         "node": ">=8.0"
     },
     "dependencies": {
-        "ilib": "^14.18.0",
-        "ilib-loctool-ghfm": "^1.11.3",
+        "ilib": "^14.19.0",
+        "ilib-loctool-ghfm": "^1.11.4",
         "ilib-loctool-json": "^1.5.3"
     },
     "devDependencies": {
-        "jest": "^26.6.3",
+        "conditional-install": "^1.0.1",
         "loctool": "^2.23.1"
+    },
+    "conditionalDependencies": {
+        "process.versions.node < 14.0.0": {
+            "jest": "^26.0.0",
+            "jest-mock": "^26.0.0",
+            "expect": "^26.0.0"
+        },
+        "process.versions.node >= 14.0.0": {
+            "jest": "^29.0.0",
+            "jest-mock": "^29.0.0",
+            "expect": "^29.0.0"
+        }
     }
 }

--- a/test/OpenAPIFile.test.js
+++ b/test/OpenAPIFile.test.js
@@ -48,6 +48,11 @@ var p = new CustomProject({
                 method: 'copy',
                 template: 'resources/[localeDir]/openapi.json'
             },
+            '**/openapi-empty-objs.json': {
+                schema: 'openapi-schema',
+                method: 'copy',
+                template: 'resources/[localeDir]/openapi-empty-objs.json'
+            },
             '**/custom.json': {
                 schema: 'custom-schema',
                 method: 'copy',
@@ -624,7 +629,7 @@ describe("openapifile", function() {
     });
 
     describe("localize", function() {
-        test("Localize", function() {
+        test("Localize a file", function() {
             expect.assertions(4);
 
             var base = path.dirname(module.id);
@@ -765,6 +770,174 @@ describe("openapifile", function() {
                 '                    "200": {\n' +
                 '                        "description": "ОК Ответ"\n' +
                 '                    }\n' +
+                '                }\n' +
+                '            }\n' +
+                '        },\n' +
+                '        "/markdown": {\n' +
+                '            "post": {\n' +
+                '                "summary": "Test path with markdown",\n' +
+                '                "description": "Markdown строка с `code` в ней",\n' +
+                '                "responses": {\n' +
+                '                    "200": {\n' +
+                '                        "description": "`code only string`"\n' +
+                '                    },\n' +
+                '                    "404": {\n' +
+                '                        "description": "Не Найдено\\n\\nresponse with markdown break line"\n' +
+                '                    }\n' +
+                '                }\n' +
+                '            }\n' +
+                '        }\n' +
+                '    }\n' +
+                '}\n';
+
+            expect(content).toBe(expected);
+        });
+
+        test("Localize a file with empty objects in it", function() {
+            expect.assertions(4);
+
+            var base = path.dirname(module.id);
+            if (fs.existsSync(path.join(base, 'testfiles/resources/ru/RU/openapi-empty-objs.json'))) {
+                fs.unlinkSync(path.join(base, 'testfiles/resources/ru/RU/openapi-empty-objs.json'));
+            }
+
+            expect(!fs.existsSync(path.join(base, 'testfiles/resources/ru/RU/openapi-empty-objs.json'))).toBeTruthy();
+
+            var oaf = new OpenAPIFile({
+                project: p,
+                type: t,
+                pathName: './openapi-empty-objs.json'
+            });
+
+            expect(oaf).toBeTruthy();
+
+            oaf.extract();
+
+            var translations = new TranslationSet();
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('File used for testing OpenAPI parser'),
+                source: 'This is a test description',
+                sourceLocale: 'en-US',
+                target: 'Файл используется для тестирования OpenAPI парсера',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('OpenAPI docs'),
+                source: 'OpenAPI docs',
+                sourceLocale: 'en-US',
+                target: 'OpenAPI документация',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('Test path without markdown'),
+                source: 'Test path without markdown',
+                sourceLocale: 'en-US',
+                target: 'Тестовый путь без markdown',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+            translations.add(new ResourceArray({
+                project: 'foo',
+                key: 'paths//json/get/tags',
+                sourceArray: [
+                    'First Tag',
+                    'Second Tag',
+                    'Third Tag'
+                ],
+                sourceLocale: 'en-US',
+                targetArray: [
+                    'Первый Тэг',
+                    'Второй Тэг',
+                    'Третий Тэг'
+                ],
+                targetLocale: 'ru-RU',
+                datatype: 'json'
+            }));
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('Param parsing'),
+                source: 'Param parsing',
+                sourceLocale: 'en-US',
+                target: 'Парсинг параметров',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('OK Response'),
+                source: 'OK Response',
+                sourceLocale: 'en-US',
+                target: 'ОК Ответ',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('Markdown string with <c0/> in it'),
+                source: 'Markdown string with <c0/> in it',
+                sourceLocale: 'en-US',
+                target: 'Markdown строка с <c0/> в ней',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+            translations.add(new ResourceString({
+                project: 'foo',
+                key: oaf.makeKey('Not Found'),
+                source: 'Not Found',
+                sourceLocale: 'en-US',
+                target: 'Не Найдено',
+                targetLocale: 'ru-RU',
+                datatype: 'markdown'
+            }));
+
+            oaf.localize(translations, ['ru-RU']);
+            expect(fs.existsSync(path.join(base, 'testfiles/resources/ru/RU/openapi-empty-objs.json'))).toBeTruthy();
+
+            var content = fs.readFileSync(path.join(base, 'testfiles/resources/ru/RU/openapi-empty-objs.json'), 'utf-8');
+
+            var expected = '{\n' +
+                '    "openapi": "3.0.0",\n' +
+                '    "info": {\n' +
+                '        "title": "Test OpenAPI File",\n' +
+                '        "description": "Файл используется для тестирования OpenAPI парсера",\n' +
+                '        "version": "1.0.0"\n' +
+                '    },\n' +
+                '    "servers": [\n' +
+                '        {\n' +
+                '            "url": "https://swagger.io/specification/",\n' +
+                '            "description": "OpenAPI документация"\n' +
+                '        }\n' +
+                '    ],\n' +
+                '    "paths": {\n' +
+                '        "/json": {\n' +
+                '            "get": {\n' +
+                '                "summary": "Тестовый путь без markdown",\n' +
+                '                "description": "Test path to verify simple json parser",\n' +
+                '                "tags": [\n' +
+                '                    "Первый Тэг",\n'+
+                '                    "Второй Тэг",\n'+
+                '                    "Третий Тэг"\n'+
+                '                ],\n' +
+                '                "parameters": [\n' +
+                '                    {},\n' +
+                '                    {\n' +
+                '                        "name": "testParam",\n' +
+                '                        "in": "query",\n' +
+                '                        "description": "Парсинг параметров"\n' +
+                '                    }\n' +
+                '                ],\n' +
+                '                "responses": {\n' +
+                '                    "200": {\n' +
+                '                        "description": "ОК Ответ"\n' +
+                '                    }\n' +
+                '                },\n' +
+                '                "nonlocalized": {\n' +
+                '                    "test": {}\n' +
                 '                }\n' +
                 '            }\n' +
                 '        },\n' +

--- a/test/testfiles/openapi-empty-objs.json
+++ b/test/testfiles/openapi-empty-objs.json
@@ -1,0 +1,57 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Test OpenAPI File",
+        "description": "File used for testing OpenAPI parser",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://swagger.io/specification/",
+            "description": "OpenAPI docs"
+        }
+    ],
+    "paths": {
+        "/json": {
+            "get": {
+                "summary": "Test path without markdown",
+                "description": "Test path to verify simple json parser",
+                "tags": [
+                    "First Tag",
+                    "Second Tag",
+                    "Third Tag"
+                ],
+                "parameters": [
+                    {},
+                    {
+                        "name": "testParam",
+                        "in": "query",
+                        "description": "Param parsing"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK Response"
+                    }
+                },
+                "nonlocalized": {
+                    test: {}
+                }
+            }
+        },
+        "/markdown": {
+            "post": {
+                "summary": "Test path with markdown",
+                "description": "Markdown string with `code` in it",
+                "responses": {
+                    "200": {
+                        "description": "`code only string`"
+                    },
+                    "404": {
+                        "description": "Not Found\n\nresponse with markdown break line"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/testfiles/openapi-empty-objs.json
+++ b/test/testfiles/openapi-empty-objs.json
@@ -35,7 +35,7 @@
                     }
                 },
                 "nonlocalized": {
-                    test: {}
+                    "test": {}
                 }
             }
         },


### PR DESCRIPTION
- fixed a bug where array entries without any localizable values in them were being coming out as `null` in the localized json files.
- updated dependencies

Cannot be merged until the [ilib-loctool-json PR](https://github.com/iLib-js/ilib-loctool-json/pull/20) is merged.